### PR TITLE
Refactor: use Skapm and fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
           - ubuntu-latest
         ocaml-version:
           - 4.11.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,7 @@
-name: CI checks
+name: CI
 
 on:
   - push
-  - pull_request
 
 jobs:
   build:
@@ -27,7 +26,10 @@ jobs:
         uses: avsm/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-version }}
+          opam-depext: false
+          opam-pin: false
 
+      - run: opam pin add skapm.dev -n https://github.com/skolemlabs/skapm.git
       - run: opam pin add skmysql.dev -n .
       - run: opam depext -yt skmysql
       - run: opam install -t . --deps-only

--- a/dune-project
+++ b/dune-project
@@ -22,4 +22,4 @@
   (ocamlgraph (>= 2.0.0))
   (rresult (>= 0.6.0))
   (uri (>= 4.2.0))
-  (elastic-apm :build)))
+  (skapm :build)))

--- a/example/dune
+++ b/example/dune
@@ -1,3 +1,3 @@
 (executables
  (names skmysql_example)
- (libraries skmysql elastic-apm))
+ (libraries skmysql skapm))

--- a/example/skmysql_example.ml
+++ b/example/skmysql_example.ml
@@ -40,10 +40,10 @@ module Table = Skmysql.Make (Table_def)
 
 let example =
   ( Lwt.return_unit >|= fun () ->
-    let trace = Elastic_apm.Trace.init () in
+    let trace = Skapm.Trace.init () in
     let skint = Random.bits () in
     let (_, transaction) =
-      Elastic_apm.Transaction.make_transaction ~trace ~name:"main"
+      Skapm.Transaction.make_transaction ~trace ~name:"main"
         ~type_:"function" ()
     in
     Table.insert ~apm:transaction conn { skint; skstr = "skmysql" }
@@ -63,8 +63,8 @@ let example =
       [ { skint = 1; skstr = "str1" }; { skint = 2; skstr = "str2" } ]
     |> Result.get_ok;
 
-    let (_ : Elastic_apm.Transaction.result) =
-      Elastic_apm.Transaction.finalize_and_send transaction
+    let (_ : Skapm.Transaction.result) =
+      Skapm.Transaction.finalize_and_send transaction
     in
     ()
   )
@@ -75,8 +75,8 @@ let () =
   let apm_secret_token = Sys.getenv "APM_SECRET_TOKEN" in
   let apm_url = Sys.getenv "APM_URL" |> Uri.of_string in
   let context =
-    Elastic_apm.Context.make ~secret_token:apm_secret_token
+    Skapm.Context.make ~secret_token:apm_secret_token
       ~service_name:apm_service_name ~apm_server:apm_url ()
   in
-  Elastic_apm.Apm.init context;
+  Skapm.Apm.init context;
   Lwt_main.run example |> ignore

--- a/skmysql.opam
+++ b/skmysql.opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlgraph" {>= "2.0.0"}
   "rresult" {>= "0.6.0"}
   "uri" {>= "4.2.0"}
-  "elastic-apm" {build}
+  "skapm" {build}
   "odoc" {with-doc}
 ]
 build: [

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,3 @@
 (library
  (public_name skmysql)
- (libraries astring calendar fmt mysql8 ocamlgraph rresult uri elastic-apm))
+ (libraries astring calendar fmt mysql8 ocamlgraph rresult uri skapm))

--- a/src/skmysql.ml
+++ b/src/skmysql.ml
@@ -22,7 +22,7 @@ let call_with_optional_transaction
     ~(action : [ `get | `exec ])
     ~statement
     (f : unit -> 'a) =
-  let open Elastic_apm in
+  let open Skapm in
   let action =
     match action with
     | `get -> "get"
@@ -1246,7 +1246,7 @@ module type Db = sig
     [ `Run ] sql
 
   val insert :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     ?on_duplicate_key_update:
       [ `All
       | `Columns of Column.packed_spec list
@@ -1258,7 +1258,7 @@ module type Db = sig
     (unit, [> `Msg of string ]) result
 
   val insert_exn :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     ?on_duplicate_key_update:
       [ `All
       | `Columns of Column.packed_spec list
@@ -1281,7 +1281,7 @@ module type Db = sig
     [ `Run ] sql
 
   val insert_many :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     ?on_duplicate_key_update:
       [ `All
       | `Columns of Column.packed_spec list
@@ -1293,7 +1293,7 @@ module type Db = sig
     (unit, [> `Msg of string ]) result
 
   val insert_many_exn :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     ?on_duplicate_key_update:
       [ `All
       | `Columns of Column.packed_spec list
@@ -1310,13 +1310,13 @@ module type Db = sig
   val update_sql : ('a, Format.formatter, unit, [ `Run ] sql) format4 -> 'a
 
   val update :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     Mysql.dbd ->
     ('a, Format.formatter, unit, (unit, [> `Msg of string ]) result) format4 ->
     'a
 
   val update_exn :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     Mysql.dbd ->
     ('a, Format.formatter, unit, unit) format4 ->
     'a
@@ -1324,13 +1324,13 @@ module type Db = sig
   val select_sql : ('a, Format.formatter, unit, [ `Get ] sql) format4 -> 'a
 
   val select :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     Mysql.dbd ->
     ('a, Format.formatter, unit, (t list, [> `Msg of string ]) result) format4 ->
     'a
 
   val select_exn :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     Mysql.dbd ->
     ('a, Format.formatter, unit, t list) format4 ->
     'a
@@ -1338,13 +1338,13 @@ module type Db = sig
   val delete_sql : ('a, Format.formatter, unit, [ `Run ] sql) format4 -> 'a
 
   val delete :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     Mysql.dbd ->
     ('a, Format.formatter, unit, (unit, [> `Msg of string ]) result) format4 ->
     'a
 
   val delete_exn :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     Mysql.dbd ->
     ('a, Format.formatter, unit, unit) format4 ->
     'a

--- a/src/skmysql.ml
+++ b/src/skmysql.ml
@@ -253,9 +253,9 @@ module Column = struct
 
   let spec_to_sql_type (type o s) (spec : (o, s) spec) =
     match spec with
-    | Char ({ width; _ }, _) -> Fmt.strf "char(%d)" width
-    | Varchar ({ width; _ }, _) -> Fmt.strf "varchar(%d)" width
-    | Binary ({ width; _ }, _) -> Fmt.strf "binary(%d)" width
+    | Char ({ width; _ }, _) -> Fmt.str "char(%d)" width
+    | Varchar ({ width; _ }, _) -> Fmt.str "varchar(%d)" width
+    | Binary ({ width; _ }, _) -> Fmt.str "binary(%d)" width
     | Blob _ -> "longblob"
     | Tiny_int _ -> "tinyint"
     | Small_int _ -> "smallint"
@@ -487,7 +487,7 @@ module Field = struct
     | Mysql.DecimalTy -> "DecimalTy"
 
   let error_to_string = function
-    | Unhandled_type typ -> Fmt.strf "Unhandled_type %s" (string_of_dbty typ)
+    | Unhandled_type typ -> Fmt.str "Unhandled_type %s" (string_of_dbty typ)
 
   let datetime_of_tuple (y, m, d, hh, mm, ss) = Datetime.make y m d hh mm ss
 
@@ -625,7 +625,7 @@ let on_duplicate_key_update' update row =
       in
       (* If a column is specified, make sure last_insert_id identifies that
          value once/if this insert completes successfully. *)
-      Fmt.strf "%a%s = last_insert_id(%s)" pp_sep () column column
+      Fmt.str "%a%s = last_insert_id(%s)" pp_sep () column column
   in
   (columns, id_column_sql)
 
@@ -650,15 +650,15 @@ let insert_many ?on_duplicate_key_update dbd ~into rows =
 
 let replace = `Use_insert_on_duplicate_key_update
 
-let update table fmt = Fmt.kstr (fun s -> Fmt.strf "update %s %s" table s) fmt
+let update table fmt = Fmt.kstr (fun s -> Fmt.str "update %s %s" table s) fmt
 
 let delete ~from:table fmt =
-  Fmt.kstr (fun s -> Fmt.strf "delete from %s %s" table s) fmt
+  Fmt.kstr (fun s -> Fmt.str "delete from %s %s" table s) fmt
 
 let select columns ~from:table fmt =
   Fmt.kstr
     (fun s ->
-      Fmt.strf "select %a from %s %s"
+      Fmt.str "select %a from %s %s"
         Fmt.(list ~sep:comma string)
         columns table s
       )
@@ -988,7 +988,7 @@ module Table = struct
       in
       if not everything_ok then
         invalid_arg
-        @@ Fmt.strf
+        @@ Fmt.str
              "Skmysql.Table.make_foreign_key refers to columns absent from %s"
              foreign_table.name;
       { key_name; keys = { foreign_table; key_mapping }; on_update; on_delete }

--- a/src/skmysql.mli
+++ b/src/skmysql.mli
@@ -468,7 +468,7 @@ val run_exn : Mysql.dbd -> [ `Run ] sql -> unit
     @raise Mysql.Error if there was problem during execution of [sql]. *)
 
 val get :
-  ?apm:Elastic_apm.Transaction.t ->
+  ?apm:Skapm.Transaction.t ->
   Mysql.dbd ->
   [ `Get ] sql ->
   (row list, [> `Msg of string ]) result
@@ -689,7 +689,7 @@ module type Db = sig
       the same database! Use with care. *)
 
   val insert :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     ?on_duplicate_key_update:
       [ `All
       | `Columns of Column.packed_spec list
@@ -704,7 +704,7 @@ module type Db = sig
       [on_duplicate_key_update] parameter. *)
 
   val insert_exn :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     ?on_duplicate_key_update:
       [ `All
       | `Columns of Column.packed_spec list
@@ -733,7 +733,7 @@ module type Db = sig
       @raise Failure "hd" if the list is empty. *)
 
   val insert_many :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     ?on_duplicate_key_update:
       [ `All
       | `Columns of Column.packed_spec list
@@ -746,7 +746,7 @@ module type Db = sig
   (** Like {!insert_many} except it takes multiple instances of type {!t} *)
 
   val insert_many_exn :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     ?on_duplicate_key_update:
       [ `All
       | `Columns of Column.packed_spec list
@@ -769,7 +769,7 @@ module type Db = sig
       without running it. *)
 
   val update :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     Mysql.dbd ->
     ('a, Format.formatter, unit, (unit, [> `Msg of string ]) result) format4 ->
     'a
@@ -779,7 +779,7 @@ module type Db = sig
       can use the {!Pp} module to properly quote arguments. *)
 
   val update_exn :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     Mysql.dbd ->
     ('a, Format.formatter, unit, unit) format4 ->
     'a
@@ -792,7 +792,7 @@ module type Db = sig
       without running it. *)
 
   val select :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     Mysql.dbd ->
     ('a, Format.formatter, unit, (t list, [> `Msg of string ]) result) format4 ->
     'a
@@ -800,7 +800,7 @@ module type Db = sig
       with this module which match the given clauses in [fmt_string]. *)
 
   val select_exn :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     Mysql.dbd ->
     ('a, Format.formatter, unit, t list) format4 ->
     'a
@@ -814,7 +814,7 @@ module type Db = sig
       without running it. *)
 
   val delete :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     Mysql.dbd ->
     ('a, Format.formatter, unit, (unit, [> `Msg of string ]) result) format4 ->
     'a
@@ -822,7 +822,7 @@ module type Db = sig
       with this module which match the given clauses in [fmt_string]. *)
 
   val delete_exn :
-    ?apm:Elastic_apm.Transaction.t ->
+    ?apm:Skapm.Transaction.t ->
     Mysql.dbd ->
     ('a, Format.formatter, unit, unit) format4 ->
     'a


### PR DESCRIPTION
This uses `skapm` rather than `elastic_apm` and fixes CI as a result.