### PR TITLE
fix: remove strict dependency on `ocamlformat`

### DIFF
--- a/skmysql.opam
+++ b/skmysql.opam
@@ -20,7 +20,6 @@ depends: [
   "uri" {>= "4.1.0"}
   "skapm" {build}
   "odoc" {with-doc}
-  "ocamlformat" {= "0.18.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
This was causing other packages not to be installed because of `ppxlib` constraints. 