### PR TITLE
feat: add `rows_affected` function

### DIFF
--- a/src/skmysql.ml
+++ b/src/skmysql.ml
@@ -664,6 +664,14 @@ let select columns ~from:table fmt =
       )
     fmt
 
+let rows_affected ?apm dbd =
+  let f () = Mysql8.affected dbd in
+  match apm with
+  | Some transaction ->
+    Skapm.Util.wrap_call ~name:"#rows_affected" ~type_:"DB" ~subtype:"MySQL"
+      ~action:"rows_affected" ~parent:(`Transaction transaction) f
+  | None -> f ()
+
 let field_of_mysql_type_exn typ s =
   match Field.of_mysql_type typ s with
   | Ok f -> f

--- a/src/skmysql.ml
+++ b/src/skmysql.ml
@@ -575,9 +575,9 @@ let make_run fmt = Fmt.kstr (fun x -> x) fmt
 let make_get fmt = Fmt.kstr (fun x -> x) fmt
 
 let insert' dbd ~into:table fields fmt =
-  let sanitize cols = List.map (fun col -> Fmt.str "`%s`" col) cols in 
+  let sanitize cols = List.map (fun col -> Fmt.str "`%s`" col) cols in
   let columns = Row.keys fields in
-  let columns = sanitize columns in 
+  let columns = sanitize columns in
   let values = Row.values fields in
   Fmt.kstr
     (fun s ->
@@ -649,8 +649,6 @@ let insert_many ?on_duplicate_key_update dbd ~into rows =
     insert_many' dbd ~into rows "on duplicate key update %a%s"
       (Fmt.list ~sep:Fmt.comma pp_update)
       columns id_column_sql
-
-let replace = `Use_insert_on_duplicate_key_update
 
 let update table fmt = Fmt.kstr (fun s -> Fmt.str "update %s %s" table s) fmt
 
@@ -1281,6 +1279,30 @@ module type Db = sig
     t ->
     unit
 
+  val insert_with_count :
+    ?apm:Skapm.Transaction.t ->
+    ?on_duplicate_key_update:
+      [ `All
+      | `Columns of Column.packed_spec list
+      | `Except of Column.packed_spec list
+      | `With_id of (_, _) Column.spec * Column.packed_spec list
+      ] ->
+    Mysql.dbd ->
+    t ->
+    (int64, [> `Msg of string ]) result
+
+  val insert_with_count_exn :
+    ?apm:Skapm.Transaction.t ->
+    ?on_duplicate_key_update:
+      [ `All
+      | `Columns of Column.packed_spec list
+      | `Except of Column.packed_spec list
+      | `With_id of (_, _) Column.spec * Column.packed_spec list
+      ] ->
+    Mysql.dbd ->
+    t ->
+    int64
+
   val insert_many_sql :
     ?on_duplicate_key_update:
       [ `All
@@ -1316,8 +1338,29 @@ module type Db = sig
     t list ->
     unit
 
-  val replace : [ `Use_insert_on_duplicate_key_update ]
-    [@@ocaml.deprecated "Use 'insert ~on_duplicate_key_update' instead"]
+  val insert_many_with_count :
+    ?apm:Skapm.Transaction.t ->
+    ?on_duplicate_key_update:
+      [ `All
+      | `Columns of Column.packed_spec list
+      | `Except of Column.packed_spec list
+      | `With_id of (_, _) Column.spec * Column.packed_spec list
+      ] ->
+    Mysql.dbd ->
+    t list ->
+    (int64, [> `Msg of string ]) result
+
+  val insert_many_with_count_exn :
+    ?apm:Skapm.Transaction.t ->
+    ?on_duplicate_key_update:
+      [ `All
+      | `Columns of Column.packed_spec list
+      | `Except of Column.packed_spec list
+      | `With_id of (_, _) Column.spec * Column.packed_spec list
+      ] ->
+    Mysql.dbd ->
+    t list ->
+    int64
 
   val update_sql : ('a, Format.formatter, unit, [ `Run ] sql) format4 -> 'a
 
@@ -1422,6 +1465,15 @@ module Make (M : S) : Db with type t := M.t = struct
       ~statement:sql (fun () -> run_exn dbd sql
     )
 
+  let insert_with_count ?apm ?on_duplicate_key_update dbd t =
+    let ( >>= ) = Result.bind in
+    insert ?apm ?on_duplicate_key_update dbd t >>= fun () ->
+    Ok (rows_affected dbd)
+
+  let insert_with_count_exn ?apm ?on_duplicate_key_update dbd t =
+    let () = insert_exn ?apm ?on_duplicate_key_update dbd t in
+    rows_affected dbd
+
   let insert_many_sql ?on_duplicate_key_update dbd rows =
     let rows = List.map M.to_row rows in
     let on_duplicate_key_update =
@@ -1444,7 +1496,14 @@ module Make (M : S) : Db with type t := M.t = struct
       ~statement:sql (fun () -> run_exn dbd sql
     )
 
-  let replace = `Use_insert_on_duplicate_key_update
+  let insert_many_with_count ?apm ?on_duplicate_key_update dbd rows =
+    let ( >>= ) = Result.bind in
+    insert_many ?apm ?on_duplicate_key_update dbd rows >>= fun () ->
+    Ok (rows_affected ?apm dbd)
+
+  let insert_many_with_count_exn ?apm ?on_duplicate_key_update dbd rows =
+    let () = insert_many_exn ?apm ?on_duplicate_key_update dbd rows in
+    rows_affected dbd
 
   let update_sql_short = Fmt.str "UPDATE %s" M.table.Table.name
 

--- a/src/skmysql.mli
+++ b/src/skmysql.mli
@@ -837,6 +837,20 @@ module type Db = sig
 
       @raise Mysql.Error if the operation fails. *)
 
+  val update_with_count :
+    ?apm:Skapm.Transaction.t ->
+    Mysql.dbd ->
+    ('a, Format.formatter, unit, (int64, [> `Msg of string ]) result) format4 ->
+    'a
+  (** Like {!update} except it returns the number of rows affected *)
+
+  val update_with_count_exn :
+    ?apm:Skapm.Transaction.t ->
+    Mysql.dbd ->
+    ('a, Format.formatter, unit, int64) format4 ->
+    'a
+  (** Like {!update_exn} except it returns the number of rows affected *)
+
   val select_sql : ('a, Format.formatter, unit, [ `Get ] sql) format4 -> 'a
   (** Like {!select} but only generates and returns the SQL for the query
       without running it. *)

--- a/src/skmysql.mli
+++ b/src/skmysql.mli
@@ -455,6 +455,10 @@ val select :
     {b NOTE}: The function is like {!Fmt.strf} in the quotations it takes. You
     can use the {!Pp} module to properly quote arguments. *)
 
+val rows_affected : ?apm:Skapm.Transaction.t -> Mysql.dbd -> int64
+(** [rows_affected dbd] returns the number of rows affected by the previous
+    query. Usually used for instrumenting/profiling queries. *)
+
 val run : Mysql.dbd -> [ `Run ] sql -> (unit, [> `Msg of string ]) result
 (** [run dbd sql] runs [sql] against the connection [dbd] strictly for
     side-effects.

--- a/src/skmysql.mli
+++ b/src/skmysql.mli
@@ -428,9 +428,6 @@ val insert_many :
     inserting an empty list is a syntax error in MySQL, and we need the first
     element of the list to get the conversion. *)
 
-val replace : [ `Use_insert_on_duplicate_key_update ]
-  [@@ocaml.deprecated "Use 'insert ~on_duplicate_key_update' instead"]
-
 val update : string -> ('a, Format.formatter, unit, [ `Run ] sql) format4 -> 'a
 (** [update table fmt] creates an update statement against [table].
 
@@ -722,6 +719,32 @@ module type Db = sig
 
       @raise Mysql.Error if the operation fails. *)
 
+  val insert_with_count :
+    ?apm:Skapm.Transaction.t ->
+    ?on_duplicate_key_update:
+      [ `All
+      | `Columns of Column.packed_spec list
+      | `Except of Column.packed_spec list
+      | `With_id of (_, _) Column.spec * Column.packed_spec list
+      ] ->
+    Mysql.dbd ->
+    t ->
+    (int64, [> `Msg of string ]) result
+  (** Like {!insert} except it returns the number of rows affected *)
+
+  val insert_with_count_exn :
+    ?apm:Skapm.Transaction.t ->
+    ?on_duplicate_key_update:
+      [ `All
+      | `Columns of Column.packed_spec list
+      | `Except of Column.packed_spec list
+      | `With_id of (_, _) Column.spec * Column.packed_spec list
+      ] ->
+    Mysql.dbd ->
+    t ->
+    int64
+  (** Like {!insert_exn} except it returns the number of rows affected *)
+
   val insert_many_sql :
     ?on_duplicate_key_update:
       [ `All
@@ -747,7 +770,7 @@ module type Db = sig
     Mysql.dbd ->
     t list ->
     (unit, [> `Msg of string ]) result
-  (** Like {!insert_many} except it takes multiple instances of type {!t} *)
+  (** Like {!insert} except it takes multiple instances of type {!t} *)
 
   val insert_many_exn :
     ?apm:Skapm.Transaction.t ->
@@ -765,8 +788,31 @@ module type Db = sig
       @raise Mysql.Error if the operation fails.
       @raise Failure "hd" if the list is empty. *)
 
-  val replace : [ `Use_insert_on_duplicate_key_update ]
-    [@@ocaml.deprecated "Use 'insert ~on_duplicate_key_update' instead"]
+  val insert_many_with_count :
+    ?apm:Skapm.Transaction.t ->
+    ?on_duplicate_key_update:
+      [ `All
+      | `Columns of Column.packed_spec list
+      | `Except of Column.packed_spec list
+      | `With_id of (_, _) Column.spec * Column.packed_spec list
+      ] ->
+    Mysql.dbd ->
+    t list ->
+    (int64, [> `Msg of string ]) result
+  (** Like {!insert_many} except it returns the number of rows affected *)
+
+  val insert_many_with_count_exn :
+    ?apm:Skapm.Transaction.t ->
+    ?on_duplicate_key_update:
+      [ `All
+      | `Columns of Column.packed_spec list
+      | `Except of Column.packed_spec list
+      | `With_id of (_, _) Column.spec * Column.packed_spec list
+      ] ->
+    Mysql.dbd ->
+    t list ->
+    int64
+  (** Like {!insert_many_exn} except it returns the number of rows affected *)
 
   val update_sql : ('a, Format.formatter, unit, [ `Run ] sql) format4 -> 'a
   (** Like {!update} but only generates and returns the SQL for the query


### PR DESCRIPTION
This binds to `affected` in `mysql8`, which returns the number of rows affected by the previous "execution".