### PR TITLE
feat: add debug logging to query

### DIFF
--- a/example/dune
+++ b/example/dune
@@ -1,3 +1,3 @@
 (executables
  (names skmysql_example)
- (libraries skmysql skapm))
+ (libraries skmysql skapm logs.fmt fmt.tty))

--- a/example/skmysql_example.ml
+++ b/example/skmysql_example.ml
@@ -1,5 +1,4 @@
 open Rresult
-open Lwt
 
 module Result = struct
   include Result
@@ -9,10 +8,11 @@ module Result = struct
     | Error exn -> Fmt.failwith "ERROR: %a:" R.pp_msg exn
 end
 
-let () = Printexc.record_backtrace true
+let () =
+  Logs.Src.set_level Skmysql.log_src (Some Debug);
+  Printexc.record_backtrace true
 
 let uri = Uri.of_string (Sys.getenv "SKMYSQL_URL")
-let conn = Skmysql.connect uri |> Result.get_ok
 
 module Table_def = struct
   let skint = Skmysql.Column.make_int "skint" Skmysql.Column.Conv.identity
@@ -38,53 +38,52 @@ end
 
 module Table = Skmysql.Make (Table_def)
 
-let () = Skmysql.Table.create_exn conn Table.table ~ok_if_exists:true
+let example conn =
+  let trace = Skapm.Trace.init () in
+  let skint = Random.bits () in
+  let (_, transaction) =
+    Skapm.Transaction.make_transaction ~trace ~name:"main" ~type_:"function" ()
+  in
+  let apm = `Transaction transaction in
+  Table.insert ~apm conn { skint; skstr = "skmysql" } |> Result.get_ok;
 
-let example =
-  ( Lwt.return_unit >|= fun () ->
-    let trace = Skapm.Trace.init () in
-    let skint = Random.bits () in
-    let (_, transaction) =
-      Skapm.Transaction.make_transaction ~trace ~name:"main" ~type_:"function"
-        ()
-    in
-    let apm = `Transaction transaction in
-    Table.insert ~apm conn { skint; skstr = "skmysql" } |> Result.get_ok;
+  let (_ : Table_def.t list) =
+    Table.select ~apm conn "where skint = %a" Skmysql.Pp.int skint
+    |> Result.get_ok
+  in
+  let (_ : [ `Msg of string ]) =
+    Skmysql.get ~apm conn
+      (Skmysql.select [ "skstr" ] ~from:"skmysql" "where sks = 'skmysql'")
+    |> Result.get_error
+  in
 
-    let (_ : Table_def.t list) =
-      Table.select ~apm conn "where skint = %a" Skmysql.Pp.int skint
-      |> Result.get_ok
-    in
-    let (_ : [ `Msg of string ]) =
-      Skmysql.get ~apm conn
-        (Skmysql.select [ "skstr" ] ~from:"skmysql" "where sks = 'skmysql'")
-      |> Result.get_error
-    in
+  Table.insert_many ~apm ~on_duplicate_key_update:`All conn
+    [ { skint = 1; skstr = "str1" }; { skint = 2; skstr = "str2" } ]
+  |> Result.get_ok;
 
-    Table.insert_many ~apm ~on_duplicate_key_update:`All conn
-      [ { skint = 1; skstr = "str1" }; { skint = 2; skstr = "str2" } ]
-    |> Result.get_ok;
-
-    let () =
-      let query =
-        Skmysql.make_get
-          "SELECT skmysql.skint AS s_id, skmysql.skstr FROM skmysql"
-      in
-      let rows = Skmysql.get conn query in
-      let rows = Result.get_ok rows in
-      let row = List.hd rows in
-      let (_ : int) = row |> Skmysql.get_column ~alias:"s_id" Table_def.skint in
-      ()
+  let () =
+    let query =
+      Skmysql.make_get
+        "SELECT skmysql.skint AS s_id, skmysql.skstr FROM skmysql"
     in
-
-    let (_ : Skapm.Transaction.result) =
-      Skapm.Transaction.finalize_and_send transaction
-    in
+    let rows = Skmysql.get conn query in
+    let rows = Result.get_ok rows in
+    let row = List.hd rows in
+    let (_ : int) = row |> Skmysql.get_column ~alias:"s_id" Table_def.skint in
     ()
-  )
-  >>= fun () -> Lwt_unix.sleep 10.
+  in
+
+  let (_ : Skapm.Transaction.result) =
+    Skapm.Transaction.finalize_and_send transaction
+  in
+  ()
 
 let () =
+  Fmt_tty.setup_std_outputs ();
+  Logs.Src.set_level Skmysql.log_src (Some Debug);
+  Logs.set_reporter @@ Logs_fmt.reporter ();
+  let conn = Skmysql.connect uri |> Result.get_ok in
+  Skmysql.Table.create_exn conn Table.table ~ok_if_exists:true;
   let apm_service_name = "skmysql_example" in
   let apm_secret_token = Sys.getenv "APM_SECRET_TOKEN" in
   let apm_url = Sys.getenv "APM_URL" |> Uri.of_string in
@@ -93,4 +92,4 @@ let () =
       ~service_name:apm_service_name ~apm_server:apm_url ()
   in
   Skapm.Apm.init context;
-  Lwt_main.run example |> ignore
+  example conn

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,3 @@
 (library
  (public_name skmysql)
- (libraries astring calendar fmt mysql8 ocamlgraph rresult uri skapm))
+ (libraries astring calendar fmt mysql8 ocamlgraph rresult uri skapm logs))

--- a/src/skmysql.ml
+++ b/src/skmysql.ml
@@ -13,6 +13,13 @@ module Date_p = CalendarLib.Printer.Date
 module Time_p = CalendarLib.Printer.Time
 module Mysql = Mysql8
 
+let log_src =
+  Logs.Src.create ~doc:"Logger for SQL queries initiated by skmysql" "skmysql"
+
+module SQLog = struct
+  include (val Logs.src_log log_src)
+end
+
 open Rresult
 open Astring
 
@@ -28,6 +35,7 @@ let call_with_optional_transaction
     | `get -> "get"
     | `exec -> "exec"
   in
+  SQLog.debug (fun f -> f "%s: %s" action statement);
   match apm with
   | Some parent ->
     let context =
@@ -39,6 +47,7 @@ let call_with_optional_transaction
   | None -> f ()
 
 let connect_exn ?(reconnect = true) uri =
+  SQLog.debug (fun f -> f "Connecting to database %a" Uri.pp uri);
   let database =
     (* The database name to use is the path without the '/' prefix *)
     match Uri.path uri with

--- a/src/skmysql.mli
+++ b/src/skmysql.mli
@@ -5,6 +5,10 @@ module Row : Map.S with type key = string with type 'a t = 'a Map.Make(String).t
 
 module Mysql = Mysql8
 
+val log_src : Logs.Src.t
+(** [log_src] is the log source used for queries. When the level is set to
+    [Debug], queries will be logged as they are sent *)
+
 val connect :
   ?reconnect:bool -> Uri.t -> (Mysql.dbd, [> `Msg of string ]) result
 (** [connect uri] connects to [uri].


### PR DESCRIPTION
This uses `logs` to optionally log SQL queries as they occur. This is helpful for debugging complex or generated queries.