### PR TITLE
[SKO-768] Trent / Add packing for `Mysql.SetTy`

### DIFF
--- a/src/skmysql.mli
+++ b/src/skmysql.mli
@@ -196,13 +196,14 @@ end
 module Field : sig
   (** Fields (elements of a row) *)
   type _ t =
-    | String : string -> string t
     | Blob : string -> string t
+    | Date : Date.t -> Date.t t
+    | Datetime : Datetime.t -> Datetime.t t
+    | Float : float -> float t
     | Int : int -> int t
     | Int64 : int64 -> int64 t
-    | Float : float -> float t
-    | Datetime : Datetime.t -> Datetime.t t
-    | Date : Date.t -> Date.t t
+    | Set : string list -> string t
+    | String : string -> string t
     | Time : Time.t -> Time.t t
 
   type packed = Pack : _ t -> packed


### PR DESCRIPTION
__[SKO-768] Trent / Add packing for `Mysql.SetTy`__

This change adds the `Set` type, which corresponds to the `Mysql.SetTy`, in order to allow packing of sets of strings.

This is often useful for prepared statements, particularly when writing `IN` expressions to test set membership.