### PR TITLE
fix: use tail-recursive List functions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-version:
-          - 4.11.1
+          - 4.14.1
 
     runs-on: ${{ matrix.os }}
 

--- a/dune-project
+++ b/dune-project
@@ -17,7 +17,7 @@
  (depends
   mysql8
   skapm
-  (ocaml (>= 4.08.0))
+  (ocaml (>= 4.14.0))
   (astring (>= 0.8.5))
   (calendar (>= 2.04))
   (dune (>= 2.8.0))

--- a/skmysql.opam
+++ b/skmysql.opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/skolemlabs/skmysql/issues"
 depends: [
   "mysql8"
   "skapm"
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.14.0"}
   "astring" {>= "0.8.5"}
   "calendar" {>= "2.04"}
   "dune" {>= "2.8" & >= "2.8.0"}


### PR DESCRIPTION
This is to prevent stack overflows when, for instance, mapping long lists.